### PR TITLE
NDPS-389: Add Main Loom

### DIFF
--- a/loom/include/loom/Loom.h
+++ b/loom/include/loom/Loom.h
@@ -26,6 +26,9 @@ namespace loom
 		loom_free(loom);
 	}
 
+	LOOM_EXPORT Loom
+	loom_main();
+
 	LOOM_EXPORT Group
 	loom_group(Loom loom);
 
@@ -124,7 +127,11 @@ namespace loom
 
 		request->added_to_gc = false;
 		Group g = loom_group(loom);
-		request->job = job_new(group_push_next(g), _request_run, request, nullptr, "async request", nullptr);
+		if(g)
+			request->job = job_new(group_push_next(g), _request_run, request, nullptr, "async request", nullptr);
+		else
+			request->job = job_new(worker_main(), _request_run, request, nullptr, "async request", nullptr);
+
 		job_schedule(request->job);
 		return request;
 	}
@@ -137,7 +144,11 @@ namespace loom
 
 		Lambda_Request<TProc> request(std::forward<TProc>(proc));
 		Group g = loom_group(loom);
-		request.job = job_new(group_push_next(g), _request_run, &request, nullptr, "sync request", nullptr);
+		if(g)
+			request.job = job_new(group_push_next(g), _request_run, &request, nullptr, "sync request", nullptr);
+		else
+			request.job = job_new(worker_main(), _request_run, &request, nullptr, "sync request", nullptr);
+
 		job_schedule(request.job);
 		job_wait(request.job);
 		job_free(request.job);
@@ -184,7 +195,11 @@ namespace loom
 		}
 		request->added_to_gc = false;
 		Group g = loom_group(loom);
-		request->job = job_new(group_push_next(g), _request_run, request, nullptr, "async request", group);
+		if(g)
+			request->job = job_new(group_push_next(g), _request_run, request, nullptr, "async request", group);
+		else
+			request->job = job_new(worker_main(), _request_run, request, nullptr, "async request", group);
+
 		job_schedule(request->job);
 		request_free(request);
 	}

--- a/loom/include/loom/Loom.h
+++ b/loom/include/loom/Loom.h
@@ -126,7 +126,11 @@ namespace loom
 		}
 		request->added_to_gc = false;
 
-		Worker worker = (loom == loom_main()) ? worker_main() : group_push_next(loom_group(loom));
+		Worker worker = nullptr;
+		if (Group g = loom_group(loom))
+			worker = group_push_next(g);
+		else
+			worker = worker_main();
 		request->job = job_new(worker, _request_run, request, nullptr, "async request", nullptr);
 
 		job_schedule(request->job);
@@ -140,7 +144,11 @@ namespace loom
 		loom_gc(loom);
 
 		Lambda_Request<TProc> request(std::forward<TProc>(proc));
-		Worker worker = (loom == loom_main()) ? worker_main() : group_push_next(loom_group(loom));
+		Worker worker = nullptr;
+		if (Group g = loom_group(loom))
+			worker = group_push_next(g);
+		else
+			worker = worker_main();
 		request.job = job_new(worker, _request_run, &request, nullptr, "sync request", nullptr);
 
 		job_schedule(request.job);
@@ -189,7 +197,11 @@ namespace loom
 		}
 		request->added_to_gc = false;
 
-		Worker worker = (loom == loom_main()) ? worker_main() : group_push_next(loom_group(loom));
+		Worker worker = nullptr;
+		if (Group g = loom_group(loom))
+			worker = group_push_next(g);
+		else
+			worker = worker_main();
 		request->job = job_new(worker, _request_run, request, nullptr, "async request", group);
 
 		job_schedule(request->job);

--- a/loom/include/loom/Loom.h
+++ b/loom/include/loom/Loom.h
@@ -124,13 +124,10 @@ namespace loom
 			request->loom = loom;
 			request->small_req = false;
 		}
-
 		request->added_to_gc = false;
-		Group g = loom_group(loom);
-		if(g)
-			request->job = job_new(group_push_next(g), _request_run, request, nullptr, "async request", nullptr);
-		else
-			request->job = job_new(worker_main(), _request_run, request, nullptr, "async request", nullptr);
+
+		Worker worker = (loom == loom_main()) ? worker_main() : group_push_next(loom_group(loom));
+		request->job = job_new(worker, _request_run, request, nullptr, "async request", nullptr);
 
 		job_schedule(request->job);
 		return request;
@@ -143,11 +140,8 @@ namespace loom
 		loom_gc(loom);
 
 		Lambda_Request<TProc> request(std::forward<TProc>(proc));
-		Group g = loom_group(loom);
-		if(g)
-			request.job = job_new(group_push_next(g), _request_run, &request, nullptr, "sync request", nullptr);
-		else
-			request.job = job_new(worker_main(), _request_run, &request, nullptr, "sync request", nullptr);
+		Worker worker = (loom == loom_main()) ? worker_main() : group_push_next(loom_group(loom));
+		request.job = job_new(worker, _request_run, &request, nullptr, "sync request", nullptr);
 
 		job_schedule(request.job);
 		job_wait(request.job);
@@ -194,11 +188,9 @@ namespace loom
 			request->small_req = false;
 		}
 		request->added_to_gc = false;
-		Group g = loom_group(loom);
-		if(g)
-			request->job = job_new(group_push_next(g), _request_run, request, nullptr, "async request", group);
-		else
-			request->job = job_new(worker_main(), _request_run, request, nullptr, "async request", group);
+
+		Worker worker = (loom == loom_main()) ? worker_main() : group_push_next(loom_group(loom));
+		request->job = job_new(worker, _request_run, request, nullptr, "async request", group);
 
 		job_schedule(request->job);
 		request_free(request);

--- a/loom/src/loom/Group.cpp
+++ b/loom/src/loom/Group.cpp
@@ -101,7 +101,6 @@ namespace loom
 			allocator_pop();
 		}
 	};
-	static Main_Worker_Wrapper MAIN_WORKER;
 
 
 
@@ -285,6 +284,7 @@ namespace loom
 	Worker
 	worker_main()
 	{
+		static Main_Worker_Wrapper MAIN_WORKER;
 		return &MAIN_WORKER.self;
 	}
 

--- a/loom/src/loom/Loom.cpp
+++ b/loom/src/loom/Loom.cpp
@@ -27,6 +27,7 @@ namespace loom
 		Main_Loom_wrapper()
 		{
 			allocator_push(memory::clib());
+
 			self.group = nullptr;
 
 			self.pool = pool_new(SMALL_REQUEST_SIZE, REQUEST_POOL_SIZE * 2);
@@ -145,7 +146,8 @@ namespace loom
 			});
 		}
 		mutex_unlock(self->gc_mtx);
-		if(loom_group(self))
+
+		if(self != loom_main())
 			group_gc(self->group);
 	}
 }

--- a/loom/src/loom/Loom.cpp
+++ b/loom/src/loom/Loom.cpp
@@ -147,7 +147,7 @@ namespace loom
 		}
 		mutex_unlock(self->gc_mtx);
 
-		if(self != loom_main())
+		if(self->group)
 			group_gc(self->group);
 	}
 }


### PR DESCRIPTION
Add Main Loom to schedule requests on main thread in analogy with scheduling jobs on main thread.